### PR TITLE
Feat/hash router

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,18 @@
+import { Router, Route } from './router'
+
+import Home from './pages/Home'
+import Detail from './pages/Detail'
 import LaunchList from './components/LaunchList'
 
 const endpoint = 'https://api.spacexdata.com/v3/launches'
+const router = new Router(
+	new Route('home', Home),
+	new Route('detail', Detail)
+)
+const { routerElement } = router
+
+document.getElementById('app')
+	.appendChild(routerElement)
 
 fetch(endpoint)
 	.then(response => response.json())
@@ -12,7 +24,7 @@ fetch(endpoint)
 function renderData(data, node) {
 	console.log(data)
 
-	node.innerHTML = new LaunchList(data).render()
+	node.insertAdjacentHTML('beforeend', new LaunchList(data).render())
 }
 
 

--- a/src/pages/Detail.js
+++ b/src/pages/Detail.js
@@ -1,8 +1,11 @@
+import { RouterLink } from '../router'
+
 class Detail {
 	render() {
 		return `
 			<main>
 				<h1>Detail page</h1>
+				${new RouterLink('home', 'Back to home page').render()}
 			</main>
 		`
 	}

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -5,7 +5,7 @@ class Home {
 		return `
 			<main>
 				<h1>Home page</h1>
-				${new RouterLink('/detail', 'To detail page').render()}
+				${new RouterLink('detail', 'To detail page').render()}
 			</main>
 		`
 	}


### PR DESCRIPTION
Make the router a hash router to be used in production on GH pages...

> NOTE: GitHub Pages is just a cdn, when navigating to /detail it will try to search for a detail/index.html folder/file, that's why the first implementation of a pathname based router didn't work.